### PR TITLE
Add gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update \
     && apt-get install -y ruby-full \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/*
 
-USER gitpod
-
 RUN gem install jekyll bundler
+
+USER gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,11 @@
+FROM gitpod/workspace-full
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y ruby-full \
+    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/* /tmp/*
+
+USER gitpod
+
+RUN gem install jekyll bundler

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: .gitpod.Dockerfile
+
+# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 4000
+    onOpen: open-preview
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: bundle install # runs during prebuild
+    command: bundle exec jekyll serve

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/DestinationSol/DestinationSol.github.io) 
+
 Building from Source
 -----------
 In order to build the site locally, you need to have ruby installed. After that you can `cd` into the project directory and run:


### PR DESCRIPTION
this commit adds support for Gitpod.io, a free automated
dev environment that makes contributing and generally working on GitHub
projects much easier. It allows anyone to start a ready-to-code dev
environment for any branch, issue and pull request with a single click.